### PR TITLE
Constraint trace

### DIFF
--- a/src/main/scala/rise/core/TypedDSL.scala
+++ b/src/main/scala/rise/core/TypedDSL.scala
@@ -317,7 +317,10 @@ object TypedDSL {
       expr match {
         case i: Identifier =>
           val t = env
-            .getOrElse(i.name, error(s"$i has no type in the environment"))
+            .getOrElse(
+              i.name,
+              error(s"$i has no type in the environment")(Seq())
+            )
           (i.setType(t), Solution())
 
         case Lambda(x, e) =>
@@ -387,7 +390,7 @@ object TypedDSL {
     def infer(e: Expr): Expr = {
       val constraints = mutable.ArrayBuffer[Constraint]()
       val (typed_e, ftvSubs) = constrainTypes(e, constraints, mutable.Map())
-      val solution = solve(constraints) match {
+      val solution = solve(constraints, Seq()) match {
         case Solution(ts, ns, as, n2ds) =>
           Solution(
             ts.mapValues(t => ftvSubs(t)),

--- a/src/main/scala/rise/core/semantics/Data.scala
+++ b/src/main/scala/rise/core/semantics/Data.scala
@@ -16,9 +16,9 @@ final case class BoolData(b: Boolean) extends ScalarData(bool)
 
 final case class IntData(i: Int) extends ScalarData(int)
 
-final case class FloatData(f: Float) extends ScalarData(float)
+final case class FloatData(f: Float) extends ScalarData(f32)
 
-final case class DoubleData(d: Double) extends ScalarData(double)
+final case class DoubleData(d: Double) extends ScalarData(f64)
 
 final case class VectorData(v: Seq[ScalarData])
     extends Data(VectorType(v.length, v.head.dataType))

--- a/src/main/scala/rise/core/types/Type.scala
+++ b/src/main/scala/rise/core/types/Type.scala
@@ -25,8 +25,8 @@ final case class FunType[T1 <: Type, T2 <: Type](inT: T1, outT: T2)
 }
 
 final case class DepFunType[K <: Kind: KindName, T <: Type](
-  x: K#I with Kind.Explicitness,
-  t: T
+    x: K#I with Kind.Explicitness,
+    t: T
 ) extends Type {
   override def toString: String =
     s"(${x.name}: ${implicitly[KindName[K]].get} -> $t)"
@@ -40,9 +40,10 @@ final case class DepFunType[K <: Kind: KindName, T <: Type](
 
 sealed trait DataType extends Type
 
-final case class DataTypeIdentifier(name: String,
-                                    override val isExplicit: Boolean = false)
-    extends DataType
+final case class DataTypeIdentifier(
+    name: String,
+    override val isExplicit: Boolean = false
+) extends DataType
     with Kind.Identifier
     with Kind.Explicitness {
   override def toString: String = if (isExplicit) name else "_" + name

--- a/src/main/scala/rise/core/types/Type.scala
+++ b/src/main/scala/rise/core/types/Type.scala
@@ -25,8 +25,8 @@ final case class FunType[T1 <: Type, T2 <: Type](inT: T1, outT: T2)
 }
 
 final case class DepFunType[K <: Kind: KindName, T <: Type](
-    x: K#I with Kind.Explicitness,
-    t: T
+  x: K#I with Kind.Explicitness,
+  t: T
 ) extends Type {
   override def toString: String =
     s"(${x.name}: ${implicitly[KindName[K]].get} -> $t)"
@@ -40,10 +40,9 @@ final case class DepFunType[K <: Kind: KindName, T <: Type](
 
 sealed trait DataType extends Type
 
-final case class DataTypeIdentifier(
-    name: String,
-    override val isExplicit: Boolean = false
-) extends DataType
+final case class DataTypeIdentifier(name: String,
+                                    override val isExplicit: Boolean = false)
+    extends DataType
     with Kind.Identifier
     with Kind.Explicitness {
   override def toString: String = if (isExplicit) name else "_" + name
@@ -88,11 +87,19 @@ object int extends ScalarType {
   override def toString: String = "int"
 }
 
-object float extends ScalarType {
-  override def toString: String = "float"
-}
+object i8 extends ScalarType { override def toString: String = "i8" }
+object i16 extends ScalarType { override def toString: String = "i16" }
+object i32 extends ScalarType { override def toString: String = "i32" }
+object i64 extends ScalarType { override def toString: String = "i64" }
 
-object double extends ScalarType { override def toString: String = "double" }
+object u8 extends ScalarType { override def toString: String = "u8" }
+object u16 extends ScalarType { override def toString: String = "u16" }
+object u32 extends ScalarType { override def toString: String = "u32" }
+object u64 extends ScalarType { override def toString: String = "u64" }
+
+object f16 extends ScalarType { override def toString: String = "f16" }
+object f32 extends ScalarType { override def toString: String = "f32" }
+object f64 extends ScalarType { override def toString: String = "f64" }
 
 object NatType extends ScalarType { override def toString: String = "nat" }
 
@@ -105,25 +112,9 @@ sealed case class VectorType(size: Nat, elemType: DataType) extends BasicType {
   override def toString: String = s"<$size>$elemType"
 }
 
-object int2 extends VectorType(2, int)
-
-object int3 extends VectorType(3, int)
-
-object int4 extends VectorType(4, int)
-
-object int8 extends VectorType(8, int)
-
-object int16 extends VectorType(16, int)
-
-object float2 extends VectorType(2, float)
-
-object float3 extends VectorType(3, float)
-
-object float4 extends VectorType(4, float)
-
-object float8 extends VectorType(8, float)
-
-object float16 extends VectorType(16, float)
+object vec {
+  def apply(size: Nat, elemType: DataType) = VectorType(size, elemType)
+}
 
 final class NatToDataApply(val f: NatToData, val n: Nat) extends DataType {
   override def toString: String = s"$f($n)"

--- a/src/test/scala/rise/core/showRise.scala
+++ b/src/test/scala/rise/core/showRise.scala
@@ -22,7 +22,7 @@ class showRise extends test_util.Tests {
 
   private val blurXTiled2D: Expr = nFun(n =>
     fun(
-      (n `.` n `.` float) ->: (17 `.` float) ->: (n `.` n `.` float)
+      (n `.` n `.` f32) ->: (17 `.` f32) ->: (n `.` n `.` f32)
     )((matrix, weights) =>
       unslide2D o mapWorkGroup(1)(
         mapWorkGroup(0)(

--- a/src/test/scala/rise/core/structuralEquality.scala
+++ b/src/test/scala/rise/core/structuralEquality.scala
@@ -58,7 +58,7 @@ class structuralEquality extends test_util.Tests {
       )
         !=
           nFun(m =>
-            fun(ArrayType(m, float))(b =>
+            fun(ArrayType(m, f32))(b =>
               reduceSeq(fun(y => fun(x => y + x)))(0)(b)
             )
           )

--- a/src/test/scala/rise/core/traverse.scala
+++ b/src/test/scala/rise/core/traverse.scala
@@ -10,8 +10,7 @@ import scala.collection.mutable
 class traverse extends test_util.Tests {
   val e = nFun(h =>
     nFun(w =>
-      fun(ArrayType(h, ArrayType(w, float)))(input =>
-        map(map(fun(x => x)))(input)
+      fun(ArrayType(h, ArrayType(w, f32)))(input => map(map(fun(x => x)))(input)
       )
     )
   )
@@ -120,7 +119,7 @@ class traverse extends test_util.Tests {
           r ==
             nFun(h =>
               nFun(w =>
-                fun(ArrayType(h, ArrayType(w, float)))(input =>
+                fun(ArrayType(h, ArrayType(w, f32)))(input =>
                   app(fun(x => x), input)
                 )
               )
@@ -135,7 +134,7 @@ class traverse extends test_util.Tests {
 
   test("traverse an expression depth-first with global stop") {
     val e = nFun(n =>
-      fun(ArrayType(n, float))(input =>
+      fun(ArrayType(n, f32))(input =>
         input |> map(fun(x => x)) |> map(fun(x => x))
       )
     )
@@ -157,7 +156,7 @@ class traverse extends test_util.Tests {
     (result: @unchecked) match {
       case traversal.Stop(r) =>
         val expected = nFun(n =>
-          fun(ArrayType(n, float))(input => {
+          fun(ArrayType(n, f32))(input => {
             val x = identifier(freshName("x"))
             app(lambda(x, x), input |> map(fun(x => x)))
           })

--- a/src/test/scala/rise/core/typedDSL.scala
+++ b/src/test/scala/rise/core/typedDSL.scala
@@ -9,9 +9,9 @@ class typedDSL extends test_util.Tests {
     val e =
       nFun(n =>
         fun(
-          DepArrayType(n, n2dtFun(i => (i + 1) `.` float)) ->: DepArrayType(
+          DepArrayType(n, n2dtFun(i => (i + 1) `.` f32)) ->: DepArrayType(
             n,
-            n2dtFun(i => (i + 1) `.` float)
+            n2dtFun(i => (i + 1) `.` f32)
           )
         )(xs => xs |> depMapSeq(nFun(_ => mapSeq(fun(x => x)))))
       )


### PR DESCRIPTION
Based on PR #15 
Simplistic example with `infer(l(1) + l(2f))`:
```
rise.core.types.InferenceException was thrown.
inference exception: cannot unify int and f32
---- trace ----
(int -> int)  ~  (f32 -> _t3)
---------------
```
This helps for issue #14, although it is only a first step.