### PR TITLE
ToMem for the C backend

### DIFF
--- a/src/main/scala/rise/OpenCL/DSL.scala
+++ b/src/main/scala/rise/OpenCL/DSL.scala
@@ -28,7 +28,7 @@ object DSL {
       MapWorkGroup(0)()
   }
 
-  def toMem: ToMem = ToMem()()
+  def toMem: OclToMem = OclToMem()()
   def toFun(to: Expr, f: Expr): Expr = fun(x => to(f(x)))
   val toGlobal: Expr = toMem(rise.core.types.AddressSpace.Global)
   def toGlobalFun(f: Expr): Expr = toFun(toGlobal, f)

--- a/src/main/scala/rise/OpenCL/TypedDSL.scala
+++ b/src/main/scala/rise/OpenCL/TypedDSL.scala
@@ -35,7 +35,7 @@ object TypedDSL {
       toTDSL(MapWorkGroup(0)())
   }
 
-  def toMem: TDSL[ToMem] = toTDSL(ToMem()())
+  def toMem: TDSL[OclToMem] = toTDSL(OclToMem()())
   def toFun[A <: Expr, B <: Expr](
       to: TDSL[A],
       f: TDSL[B]

--- a/src/main/scala/rise/OpenCL/primitives.scala
+++ b/src/main/scala/rise/OpenCL/primitives.scala
@@ -43,7 +43,7 @@ object primitives {
       )
   }
 
-  @primitive case class ToMem()(override val t: Type = TypePlaceholder)
+  @primitive case class OclToMem()(override val t: Type = TypePlaceholder)
       extends Primitive {
     override def typeScheme: Type = implDT(t => aFunT(a => t ->: t))
   }

--- a/src/main/scala/rise/core/DSL.scala
+++ b/src/main/scala/rise/core/DSL.scala
@@ -18,6 +18,8 @@ object DSL {
   def depApp[K <: Kind](f: Expr, x: K#T): DepApp[K] = DepApp[K](f, x)()
   def literal(d: semantics.Data): Literal = Literal(d)
 
+  def toMem: ToMem = ToMem()()
+  def toMemFun(f: Expr): Expr = fun(x => toMem(f(x)))
   def makeArray(n: Int): MakeArray = primitives.MakeArray(n)()
   def cast: Cast = primitives.Cast()()
   def depJoin: DepJoin = primitives.DepJoin()()

--- a/src/main/scala/rise/core/primitives.scala
+++ b/src/main/scala/rise/core/primitives.scala
@@ -208,6 +208,11 @@ object primitives {
       )
   }
 
+  @primitive case class ToMem()(override val t: Type = TypePlaceholder)
+    extends Primitive {
+    override def typeScheme: Type = implDT(t => t ->: t)
+  }
+
   @primitive case class NatAsIndex()(override val t: Type = TypePlaceholder)
       extends Primitive {
     override def typeScheme: Type = nFunT(n => NatType ->: IndexType(n))


### PR DESCRIPTION
Introduces the ToMem primitive for the C backend.

This allows us to explicitly write an expression to memory in C and OpenMP.

It is also needed to make expressions with read-write annotations that are going to be introduced to DPIA in Shine, type check.