### PR TITLE
Moved test_util package to avoid name clash

### DIFF
--- a/src/test/scala/rise/core/infer.scala
+++ b/src/test/scala/rise/core/infer.scala
@@ -4,7 +4,7 @@ import rise.core.DSL._
 import rise.core.TypeLevelDSL._
 import rise.core.types._
 
-class infer extends test_util.Tests {
+class infer extends rise.test_util.Tests {
   test("Infer int addition type") {
     val typed = infer(l(1) + l(2))
     assert(typed.t == int)

--- a/src/test/scala/rise/core/showRise.scala
+++ b/src/test/scala/rise/core/showRise.scala
@@ -9,7 +9,7 @@ import rise.core.HighLevelConstructs._
 import rise.core.types._
 import rise.core.ShowRise._
 
-class showRise extends test_util.Tests {
+class showRise extends rise.test_util.Tests {
   private val id = fun(x => x)
 
   private val dotElemWeights = fun((weights, elem) =>

--- a/src/test/scala/rise/core/structuralEquality.scala
+++ b/src/test/scala/rise/core/structuralEquality.scala
@@ -4,7 +4,7 @@ import rise.core.DSL._
 import rise.core.TypeLevelDSL._
 import rise.core.types._
 
-class structuralEquality extends test_util.Tests {
+class structuralEquality extends rise.test_util.Tests {
   test("identity") {
     assert(fun(x => x) == fun(y => y))
   }

--- a/src/test/scala/rise/core/traverse.scala
+++ b/src/test/scala/rise/core/traverse.scala
@@ -7,7 +7,7 @@ import rise.core.DSL._
 
 import scala.collection.mutable
 
-class traverse extends test_util.Tests {
+class traverse extends rise.test_util.Tests {
   val e = nFun(h =>
     nFun(w =>
       fun(ArrayType(h, ArrayType(w, f32)))(input => map(map(fun(x => x)))(input)

--- a/src/test/scala/rise/core/typedDSL.scala
+++ b/src/test/scala/rise/core/typedDSL.scala
@@ -4,7 +4,7 @@ import rise.core.TypedDSL._
 import rise.core.TypeLevelDSL._
 import rise.core.types._
 
-class typedDSL extends test_util.Tests {
+class typedDSL extends rise.test_util.Tests {
   test("Infer int addition type") {
     val e =
       nFun(n =>

--- a/src/test/scala/rise/core/uniqueNamesCheck.scala
+++ b/src/test/scala/rise/core/uniqueNamesCheck.scala
@@ -3,7 +3,7 @@ package rise.core
 import rise.core.DSL._
 import rise.core.types._
 
-class uniqueNamesCheck extends test_util.Tests {
+class uniqueNamesCheck extends rise.test_util.Tests {
   test("beta-reducing holds unique names") {
     val f = fun(x => x(l(1)) + x(l(1)))
     val e = fun(y => y + l(1))

--- a/src/test/scala/rise/test_util/package.scala
+++ b/src/test/scala/rise/test_util/package.scala
@@ -1,3 +1,5 @@
+package rise
+
 import com.github.ghik.silencer.silent
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
This change avoids confusion :stop_sign: :confused: which `test_util.Test` should be used by which tests.

There are corresponding pull requests in the elevate and shine repos as well.